### PR TITLE
[Pick][0.8 to main] | Force set CMAKE_POLICY_VERSION_MINIMUM to make third-party libs able to compile via cmake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ project(
         LANGUAGES C CXX ASM
 )
 
+# for CMake 4.x compatible
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+
 # Utility Modules and Find Modules
 include(FindPackageHandleStandardArgs)
 include(CheckCXXCompilerFlag)


### PR DESCRIPTION
> Force set CMAKE_POLICY_VERSION_MINIMUM to make third-party libs able to compile via cmake 4

Generated by Auto PR, by cherry-pick related commits