### PR TITLE
[Pick][0.7 to 0.8] | Fix split iteration meets empty parts | FIX: estring split in non-consecutive merge mode (#1071) 

### DIFF
--- a/.github/workflows/ci.macos.arm.yml
+++ b/.github/workflows/ci.macos.arm.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   macOS14-arm:
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
       - uses: szenius/set-timezone@v2.0
@@ -31,7 +31,7 @@ jobs:
             -D CMAKE_BUILD_TYPE=MinSizeRel \
             -D PHOTON_ENABLE_SASL=ON \
             -D PHOTON_ENABLE_LIBCURL=ON \
-            -D OPENSSL_ROOT_DIR=/opt/homebrew/Cellar/openssl@1.1/1.1.1w
+            -D OPENSSL_ROOT_DIR=/opt/homebrew/Cellar/openssl@3/3.6.0
           cmake --build ${{github.workspace}}/build -j $(sysctl -n hw.logicalcpu)
 
       - name: Test

--- a/.github/workflows/ci.macos.x86_64.yml
+++ b/.github/workflows/ci.macos.x86_64.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   macOS13-x86:
-    runs-on: macos-13
+    runs-on: macos-15
 
     steps:
       - uses: szenius/set-timezone@v2.0
@@ -31,7 +31,7 @@ jobs:
             -D CMAKE_BUILD_TYPE=MinSizeRel \
             -D PHOTON_ENABLE_SASL=ON \
             -D PHOTON_ENABLE_LIBCURL=ON \
-            -D OPENSSL_ROOT_DIR=/usr/local/opt/openssl@3
+            -D OPENSSL_ROOT_DIR=/opt/homebrew/Cellar/openssl@3/3.6.0
           cmake --build ${{github.workspace}}/build -j $(sysctl -n hw.logicalcpu)
 
       - name: Test

--- a/common/estring.h
+++ b/common/estring.h
@@ -208,7 +208,8 @@ public:
             }
             bool operator == (const iterator& rhs) const
             {
-                return _part == rhs._part;
+                return _part.data() == rhs._part.data() &&
+                       _part.length() == rhs._part.length();
             }
             bool operator != (const iterator& rhs) const
             {

--- a/common/estring.h
+++ b/common/estring.h
@@ -197,7 +197,7 @@ public:
             }
             iterator& operator++()
             {
-                _part = _host->find_part(_part.end());
+                _part = _host->find_part(_part.end() + 1);
                 return *this;
             }
             iterator& operator++(int)

--- a/common/test/test.cpp
+++ b/common/test/test.cpp
@@ -863,6 +863,51 @@ TEST(estring, test)
     EXPECT_EQ(a[1], "q3r1234");
     EXPECT_EQ(a[2], "poiu");
 
+    sp = s.split(cs, false);
+    it = sp.begin();
+    front = *it;
+    remainder = it.remainder();
+    LOG_DEBUG(VALUE(front), VALUE(remainder));
+    EXPECT_EQ(front, "alskdjf");
+    EXPECT_EQ(remainder, ";;,q3r1234;poiu");
+    it ++;
+    front = *it;
+    remainder = it.remainder();
+    LOG_DEBUG(VALUE(front), VALUE(remainder));
+    EXPECT_EQ(front, "");
+    EXPECT_EQ(remainder, ";,q3r1234;poiu");
+    it ++;
+    front = *it;
+    remainder = it.remainder();
+    LOG_DEBUG(VALUE(front), VALUE(remainder));
+    EXPECT_EQ(front, "");
+    EXPECT_EQ(remainder, ",q3r1234;poiu");
+    it ++;
+    front = *it;
+    remainder = it.remainder();
+    LOG_DEBUG(VALUE(front), VALUE(remainder));
+    EXPECT_EQ(front, "");
+    EXPECT_EQ(remainder, "q3r1234;poiu");
+    it ++;
+    front = *it;
+    remainder = it.remainder();
+    LOG_DEBUG(VALUE(front), VALUE(remainder));
+    EXPECT_EQ(front, "q3r1234");
+    EXPECT_EQ(remainder, "poiu");
+
+    a.clear();
+    for (auto x: sp)
+    {
+        a.push_back(x);
+        LOG_DEBUG(x);
+    }
+
+    EXPECT_EQ(a.size(), 6);
+    EXPECT_EQ(a[0], "alskdjf");
+    EXPECT_EQ(a[4], "q3r1234");
+    EXPECT_EQ(a[5], "poiu");
+
+
     auto sv = s;//.view();
     EXPECT_TRUE(sv.starts_with("alskdjf"));
     EXPECT_FALSE(sv.starts_with("alsk32"));


### PR DESCRIPTION
> Fix split iteration meets empty parts

> FIX: estring split in non-consecutive merge mode (#1071)


Generated by Auto PR, by cherry-pick related commits